### PR TITLE
Add wall-aware parsing and DFS for Zip puzzle

### DIFF
--- a/linkedin/zip/zip_parser.py
+++ b/linkedin/zip/zip_parser.py
@@ -45,5 +45,40 @@ class ZipParser:
             raw_game.append(row)
         return raw_game
 
+    def extract_walls(self, cell: WebElement) -> tuple[bool, bool]:
+        """Return which walls are present for the given cell.
+
+        Only ``right`` and ``down`` walls are parsed to avoid
+        duplication.  The walls are detected by looking for elements
+        with the ``trail-cell-wall`` class and the directional
+        subclass ``trail-cell-wall-<direction>``.
+        """
+        right_wall = False
+        down_wall = False
+        for wall in cell.find_elements(By.CLASS_NAME, "trail-cell-wall"):
+            classes = wall.get_attribute("class").split()
+            if "trail-cell-wall-right" in classes:
+                right_wall = True
+            if "trail-cell-wall-down" in classes:
+                down_wall = True
+        return down_wall, right_wall
+
+    def dump_cells_with_walls(self) -> list[list[tuple[int | None, bool, bool]]]:
+        """Dump the board state including wall information."""
+        self.load_cells()
+        board = []
+        for row_elements in self.cells:
+            row = []
+            for cell in row_elements:
+                try:
+                    content_element = cell.find_element(By.CLASS_NAME, "trail-cell-content")
+                    content_value = int(content_element.text)
+                except Exception:
+                    content_value = None
+                down_wall, right_wall = self.extract_walls(cell)
+                row.append((content_value, down_wall, right_wall))
+            board.append(row)
+        return board
+
     def do_step(self, row: int, column: int):
         self.cells[row][column].click()

--- a/linkedin/zip/zip_solver.py
+++ b/linkedin/zip/zip_solver.py
@@ -5,8 +5,30 @@ class ZipSolver:
     def __init__(self, parser: ZipParser):
         self.parser = parser
         self.parser.load_cells()
-        self.board = self.parser.dump_cells()
-        self.size = len(self.board)
+        # include wall information when parsing the board
+        board_data = self.parser.dump_cells_with_walls()
+        self.size = len(board_data)
+
+        # store numeric values separate from wall locations
+        self.board: list[list[int | None]] = []
+        self.right_walls: list[list[bool]] = []  # walls between (r,c) and (r,c+1)
+        self.down_walls: list[list[bool]] = []   # walls between (r,c) and (r+1,c)
+
+        for r, row_data in enumerate(board_data):
+            values_row = []
+            right_row = []
+            for c, (value, down, right) in enumerate(row_data):
+                values_row.append(value)
+                if c < self.size - 1:
+                    right_row.append(right)
+            self.board.append(values_row)
+            self.right_walls.append(right_row)
+
+        for r in range(self.size - 1):
+            down_row = []
+            for c in range(self.size):
+                down_row.append(board_data[r][c][1])
+            self.down_walls.append(down_row)
 
     def find_solution(self) -> list[tuple[int, int]]:
         """
@@ -51,6 +73,23 @@ class ZipSolver:
                 if (new_r, new_c) in visited:
                     continue
 
+                # check for walls blocking the movement
+                blocked = False
+                if delta_r == 0 and delta_c == 1:
+                    if self.right_walls[row][column]:
+                        blocked = True
+                elif delta_r == 0 and delta_c == -1:
+                    if self.right_walls[row][column - 1]:
+                        blocked = True
+                elif delta_r == 1 and delta_c == 0:
+                    if self.down_walls[row][column]:
+                        blocked = True
+                elif delta_r == -1 and delta_c == 0:
+                    if self.down_walls[row - 1][column]:
+                        blocked = True
+                if blocked:
+                    continue
+
                 cell_val = self.board[new_r][new_c]
                 new_last = last_number
 
@@ -80,7 +119,8 @@ class ZipSolver:
         visited.add(start)
         path.append(start)
         # Set initial number based on the starting cell value.
-        initial_number = self.board[start[0]][start[1]] if isinstance(self.board[start[0]][start[1]], int) else 0
+        start_value = self.board[start[0]][start[1]]
+        initial_number = start_value if isinstance(start_value, int) else 0
 
         if dfs(start[0], start[1], initial_number):
             return path

--- a/linkedin/zip/zip_test.py
+++ b/linkedin/zip/zip_test.py
@@ -4,12 +4,18 @@ from zip_solver import ZipSolver
 from zip_parser import ZipParser
 
 EXAMPLE_BOARD = [
-    [  11, None, None,    6, None,    7],
-    [None, None,   10, None,    1, None],
-    [None,    3, None,     5, None, None],
-    [   9, None,    4, None, None, None],
-    [None,    2, None, None, None, None],
-    [   8, None, None, None, None, None]
+    [11, None, None, 6, None, 7],
+    [None, None, 10, None, 1, None],
+    [None, 3, None, 5, None, None],
+    [9, None, 4, None, None, None],
+    [None, 2, None, None, None, None],
+    [8, None, None, None, None, None],
+]
+
+# Each cell in the solver includes down and right wall flags.
+EXAMPLE_BOARD_WITH_WALLS = [
+    [(v, False, False) for v in row]
+    for row in EXAMPLE_BOARD
 ]
 
 SOLUTION_PATH = [
@@ -30,6 +36,7 @@ SOLUTION_PATH = [
 def test_zip_solver_solve():
     mock_parser = Mock(spec=ZipParser)
     mock_parser.load_cells.return_value = EXAMPLE_BOARD
+    mock_parser.dump_cells_with_walls.return_value = EXAMPLE_BOARD_WITH_WALLS
 
     zip_solver = ZipSolver(mock_parser)
     result = zip_solver.find_solution()


### PR DESCRIPTION
## Summary
- track right and down walls when parsing Zip boards
- store walls separately from numbered cells
- prevent DFS traversal through walls

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68737d06498483239fd0098dd4882b7e